### PR TITLE
Remove unneeded deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,15 @@ module.exports = {
     await uninstallTask.run({
       'save-dev': true,
       verbose: false,
-      packages: ['ember-fetch'],
+      packages: [
+        'ember-fetch',
+        'broccoli-asset-rev',
+        'ember-cli-app-version',
+        'ember-cli-clean-css',
+        'ember-cli-dependency-checker',
+        'ember-cli-sri',
+        'ember-cli-terser',
+      ],
       packageManager: options.packageManager,
     });
   },


### PR DESCRIPTION
Deps that are still required
- ember-auto-import (because ember-auto-import has a check to make sure the host project has ember-auto-import)
- ember-cli-babel -- something has to configure babel