### PR TITLE
docs: use npx instead of ember-cli global

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # @embroider/app-blueprint
 
-**Very** experimental blueprint for scaffolding ember v2 apps with Vite
+**Very** experimental blueprint for scaffolding Ember v2 apps with Vite
 
 This is likely to change on a daily basis so you have to keep up to date with the changes to expect it work. Use [ember-cli-update](https://github.com/ember-cli/ember-cli-update) to update to the latest version.
 
 ## Usage
 
 ```bash
-ember new my-fancy-app -b @embroider/app-blueprint --pnpm
+npx ember-cli@latest new my-fancy-app -b @embroider/app-blueprint --pnpm
 ```


### PR DESCRIPTION
I often see confusion when people run ember-cli commands using the globally installed version. This can be out of date as it's not often used. Once you're inside an app or addon folder, the local version is used and should be up to date.

Should we just recommend to use `npx` instead? That's what I personally always use. That way the version used is for sure up to date.