### PR TITLE
schedule CI to run once a day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
This is to give us an early signal if recent unstable releases of embroider have broken the app blueprint, or if the blueprint needs to be updated in any way