### PR TITLE
add regression tests for initialisers

### DIFF
--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -49,7 +49,7 @@ describe('basic functionality', function () {
     let result;
 
     try {
-      result = await execa('pnpm', ['test'], {
+      result = await execa('pnpm', ['test:ember'], {
         cwd: join(tmpDir.path, appName),
       });
     } catch (err) {

--- a/tests/fixture/app/initializers/test-init.js
+++ b/tests/fixture/app/initializers/test-init.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'test-init',
+  initialize(application) {
+    application.__test_init = 'coming from the initializer';
+  },
+};

--- a/tests/fixture/app/instance-initializers/test-instance-init.js
+++ b/tests/fixture/app/instance-initializers/test-instance-init.js
@@ -1,0 +1,6 @@
+export default {
+  name: 'test-instance-initializers',
+  initialize(instance) {
+    instance.__instance_test_init = 'set in the instance initializer';
+  },
+};

--- a/tests/fixture/tests/acceptance/app-init-test.js
+++ b/tests/fixture/tests/acceptance/app-init-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { getApplication } from '@ember/test-helpers';
+import { setupApplicationTest } from '<%= name %>/tests/helpers';
+
+module('Acceptance | app route', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('loaded initializers /', async function (assert) {
+    const app = getApplication();
+    assert.strictEqual([...app._applicationInstances][0].__instance_test_init, 'set in the instance initializer');
+    assert.strictEqual(app.__test_init, 'coming from the initializer');
+  });
+});


### PR DESCRIPTION
This test covers a case where our initialisers weren't running because of a timing change during the entrypoint loading process. https://github.com/embroider-build/embroider/pull/2006 actually fixes some of the worst problems with this timing problem and probably fixed our issues with initializers 🎉 

Fixes https://github.com/embroider-build/app-blueprint/issues/20