### PR TITLE
Add /tmp/ to files-override/.gitignore

### DIFF
--- a/files-override/.gitignore
+++ b/files-override/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist/
 /declarations/
+/tmp/
 
 # dependencies
 /node_modules/


### PR DESCRIPTION
Add `/tmp/` to the `files-override/.gitignore`

Most people might have this in their default `.gitignore` file but not all. 