### PR TITLE
Run linting on the generated project in CI // add a working eslintconfig

### DIFF
--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -74,6 +74,7 @@ export default [
       '**/*.cjs',
       'config/**/*.js',
       'testem.js',
+      'testem*.js',
       '.prettierrc.js',
       '.stylelintrc.js',
       '.template-lintrc.js',

--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -61,10 +61,10 @@ export default [
     },
   },
   {
+    files: ['tests/**/*-test.{js,gjs}'],
     plugins: {
       qunit,
     },
-    files: ['tests/**/*-test.{js,gjs}'],
   },
   /**
    * CJS node files

--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -1,0 +1,93 @@
+import globals from 'globals';
+import js from '@eslint/js';
+
+import ember from 'eslint-plugin-ember';
+import emberRecommended from 'eslint-plugin-ember/configs/recommended';
+import gjsRecommended from 'eslint-plugin-ember/configs/recommended-gjs';
+
+import prettier from 'eslint-plugin-prettier/recommended';
+import qunit from 'eslint-plugin-qunit';
+import n from 'eslint-plugin-n';
+
+import emberParser from 'ember-eslint-parser';
+import babelParser from '@babel/eslint-parser';
+
+const esmParserOptions = {
+  ecmaFeatures: { modules: true },
+  ecmaVersion: 'latest',
+  requireConfigFile: false,
+  babelOptions: {
+    plugins: [
+      ['@babel/plugin-proposal-decorators', { decoratorsBeforeExport: true }],
+    ],
+  },
+};
+
+export default [
+  js.configs.recommended,
+  prettier,
+  {
+    ignores: ['vendor/', 'dist/', 'node_modules/', 'coverage/', '!**/.*'],
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      parser: babelParser,
+      parserOptions: esmParserOptions,
+      globals: {
+        ...globals.browser,
+      },
+    },
+    plugins: {
+      ember: ember,
+    },
+    rules: {
+      ...emberRecommended.rules,
+      ...gjsRecommended.rules,
+    },
+  },
+  {
+    files: ['**/*.gjs'],
+    languageOptions: {
+      parser: emberParser,
+      parserOptions: esmParserOptions,
+      globals: {
+        ...globals.browser,
+      },
+    },
+    plugins: {
+      ember: ember,
+    },
+    rules: {
+      ...emberRecommended.rules,
+      ...gjsRecommended.rules,
+    },
+  },
+  {
+    plugins: {
+      qunit,
+    },
+    files: ['tests/**/*-test.{js,gjs}'],
+  },
+  /**
+   * CJS node files
+   */
+  {
+    files: ['**/*.cjs', 'config/**/*.js'],
+    plugins: {
+      n,
+    },
+
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+
+      ecmaVersion: 6,
+      sourceType: 'script',
+    },
+  },
+];

--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -15,12 +15,6 @@ import babelParser from '@babel/eslint-parser';
 const esmParserOptions = {
   ecmaFeatures: { modules: true },
   ecmaVersion: 'latest',
-  requireConfigFile: false,
-  babelOptions: {
-    plugins: [
-      ['@babel/plugin-proposal-decorators', { decoratorsBeforeExport: true }],
-    ],
-  },
 };
 
 export default [
@@ -76,18 +70,43 @@ export default [
    * CJS node files
    */
   {
-    files: ['**/*.cjs', 'config/**/*.js'],
+    files: [
+      '**/*.cjs',
+      'config/**/*.js',
+      'testem.js',
+      '.prettierrc.js',
+      '.stylelintrc.js',
+      '.template-lintrc.js',
+      'ember-cli-build.js',
+    ],
     plugins: {
       n,
     },
 
     languageOptions: {
+      sourceType: 'script',
+      ecmaVersion: 'latest',
       globals: {
         ...globals.node,
       },
+    },
+  },
+  /**
+   * ESM node files
+   */
+  {
+    files: ['*.mjs'],
+    plugins: {
+      n,
+    },
 
-      ecmaVersion: 6,
-      sourceType: 'script',
+    languageOptions: {
+      sourceType: 'module',
+      ecmaVersion: 'latest',
+      parserOptions: esmParserOptions,
+      globals: {
+        ...globals.node,
+      },
     },
   },
 ];

--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -36,7 +36,7 @@ export default [
       },
     },
     plugins: {
-      ember: ember,
+      ember,
     },
     rules: {
       ...emberRecommended.rules,
@@ -53,7 +53,7 @@ export default [
       },
     },
     plugins: {
-      ember: ember,
+      ember,
     },
     rules: {
       ...emberRecommended.rules,

--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -21,7 +21,7 @@ export default [
   js.configs.recommended,
   prettier,
   {
-    ignores: ['vendor/', 'dist/', 'node_modules/', 'coverage/', '!**/.*'],
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },

--- a/index.js
+++ b/index.js
@@ -149,5 +149,16 @@ module.exports = {
     });
 
     await this.updateDeps(options);
+
+    const lintFix = require('ember-cli/lib/utilities/lint-fix');
+
+    await lintFix.run({
+      // Mock Project
+      pkg: {
+        scripts: { 'lint:fix': true },
+      },
+      ui: this.ui,
+      root: options.target,
+    });
   },
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const { join } = require('path');
 const emberCliUpdate = require('./lib/ember-cli-update');
 const copyWithTemplate = require('./lib/copy-with-template');
-const { rm } = require('fs/promises');
+const { rm, readFile } = require('fs/promises');
 
 const appBlueprint = Blueprint.lookup('app');
 
@@ -36,8 +36,39 @@ module.exports = {
   },
 
   async updateDeps(options) {
+    let manifestPath = join(options.target, 'package.json');
+    let manifestBuffer = await readFile(manifestPath);
+    let manifest = JSON.parse(manifestBuffer.toString());
+
+    let existingDeps = [
+      ...Object.keys(manifest.dependencies || {}),
+      ...Object.keys(manifest.devDependencies || {}),
+    ];
+
+    let ensureLatestDeps = ['eslint', 'eslint-plugin-ember', 'eslint-plugin-n'];
+
     // this.addPackagesToProject doesn't respect the packageManager that the blueprint specified 🙈 so we're skipping a level here
     let installTask = this.taskFor('npm-install');
+    let uninstallTask = this.taskFor('npm-uninstall');
+
+    await uninstallTask.run({
+      'save-dev': true,
+      verbose: false,
+      packages: [
+        // Not needed anymore
+        'ember-fetch',
+        'broccoli-asset-rev',
+        'ember-cli-app-version',
+        'ember-cli-clean-css',
+        'ember-cli-dependency-checker',
+        'ember-cli-sri',
+        'ember-cli-terser',
+
+        ...ensureLatestDeps,
+      ].filter((depToRemove) => existingDeps.includes(depToRemove)),
+      packageManager: options.packageManager,
+    });
+
     await installTask.run({
       'save-dev': true,
       verbose: false,
@@ -50,37 +81,21 @@ module.exports = {
         'vite',
         '@rollup/plugin-babel',
         'decorator-transforms',
+
+        ...ensureLatestDeps,
+        // Needed for eslint
+        'globals',
       ],
       packageManager: options.packageManager,
     });
-
-    let uninstallTask = this.taskFor('npm-uninstall');
-    const packages = [
-      'ember-fetch',
-      'broccoli-asset-rev',
-      'ember-cli-app-version',
-      'ember-cli-clean-css',
-      'ember-cli-dependency-checker',
-      'ember-cli-sri',
-      'ember-cli-terser',
-    ];
-
-    for (const package of packages) {
-      try {
-        await uninstallTask.run({
-          'save-dev': true,
-          verbose: false,
-          packages: [package],
-          packageManager: options.packageManager,
-        });
-      } catch {
-        console.log(`Could not uninstall ${package}`);
-      }
-    }
   },
 
   async afterInstall(options) {
-    const filesToDelete = ['app/index.html'];
+    const filesToDelete = [
+      'app/index.html',
+      // replaced with the new ESLint flat config
+      '.eslintrc.js',
+    ];
 
     for (let file of filesToDelete) {
       await rm(join(options.target, file));

--- a/index.js
+++ b/index.js
@@ -45,7 +45,12 @@ module.exports = {
       ...Object.keys(manifest.devDependencies || {}),
     ];
 
-    let ensureLatestDeps = ['eslint', 'eslint-plugin-ember', 'eslint-plugin-n'];
+    let ensureLatestDeps = [
+      'eslint',
+      'eslint-plugin-ember',
+      'eslint-plugin-n',
+      '@babel/eslint-parser',
+    ];
 
     // this.addPackagesToProject doesn't respect the packageManager that the blueprint specified 🙈 so we're skipping a level here
     let installTask = this.taskFor('npm-install');
@@ -65,6 +70,8 @@ module.exports = {
         'ember-cli-terser',
 
         ...ensureLatestDeps,
+        // Linting
+        '@babel/plugin-proposal-decorators',
       ].filter((depToRemove) => existingDeps.includes(depToRemove)),
       packageManager: options.packageManager,
     });
@@ -85,6 +92,7 @@ module.exports = {
         ...ensureLatestDeps,
         // Needed for eslint
         'globals',
+        'babel-plugin-ember-template-compilation',
       ],
       packageManager: options.packageManager,
     });
@@ -95,6 +103,8 @@ module.exports = {
       'app/index.html',
       // replaced with the new ESLint flat config
       '.eslintrc.js',
+      // This file is not supported in ESLint 9
+      '.eslintignore',
     ];
 
     for (let file of filesToDelete) {

--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -54,6 +54,14 @@ describe('basic functionality', function () {
     );
   });
 
+  it('successfully lints', async function () {
+    let result = await execa('pnpm', ['lint'], {
+      cwd: join(tmpDir.path, appName),
+    });
+
+    console.log(result.stdout);
+  });
+
   it('successfully builds', async function () {
     let result = await execa('pnpm', ['build'], {
       cwd: join(tmpDir.path, appName),

--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -33,6 +33,11 @@ describe('basic functionality', function () {
     copyWithTemplate(join(__dirname, 'fixture'), join(tmpDir.path, appName), {
       name: appName,
     });
+
+    // Sync the lints for the fixtures with the project's config
+    await execa(`pnpm`, ['lint:fix'], {
+      cwd: join(tmpDir.path, appName),
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Unblocks CI verifying that https://github.com/embroider-build/app-blueprint/pull/83 is correct

- Adds linting to the tests
- Adds an eslint config
  - ESLint 9
  - Flat config (all ESLint 9 supports)
  - GJS support 