### PR TITLE
Use local ember-cli instead of global

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "ember-cli": "^5.11.0",
     "lodash": "^4.17.21",
-    "package-up": "^5.0.0",
     "resolve-bin": "^1.0.1",
     "walk-sync": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "ember-cli": "^5.11.0",
     "lodash": "^4.17.21",
-    "resolve-bin": "^1.0.1",
     "walk-sync": "^3.0.0"
   },
   "devDependencies": {
@@ -32,6 +31,7 @@
     "prettier": "^3.2.5",
     "prettier-plugin-ember-template-tag": "^2.0.2",
     "release-plan": "^0.9.0",
+    "resolve-bin": "^1.0.1",
     "strip-ansi": "^7.1.0",
     "tmp-promise": "^3.0.3",
     "vitest": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "ember-cli": "^5.11.0",
     "lodash": "^4.17.21",
+    "package-up": "^5.0.0",
     "walk-sync": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ember-cli": "^5.11.0",
     "lodash": "^4.17.21",
     "package-up": "^5.0.0",
+    "resolve-bin": "^1.0.1",
     "walk-sync": "^3.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      package-up:
-        specifier: ^5.0.0
-        version: 5.0.0
       resolve-bin:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1946,10 +1943,6 @@ packages:
   find-parent-dir@0.3.1:
     resolution: {integrity: sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==}
 
-  find-up-simple@1.0.0:
-    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
-    engines: {node: '>=18'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3190,10 +3183,6 @@ packages:
   package-json@6.5.0:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
     engines: {node: '>=8'}
-
-  package-up@5.0.0:
-    resolution: {integrity: sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==}
-    engines: {node: '>=18'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6520,8 +6509,6 @@ snapshots:
 
   find-parent-dir@0.3.1: {}
 
-  find-up-simple@1.0.0: {}
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -7869,10 +7856,6 @@ snapshots:
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
       semver: 6.3.1
-
-  package-up@5.0.0:
-    dependencies:
-      find-up-simple: 1.0.0
 
   parent-module@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      resolve-bin:
-        specifier: ^1.0.1
-        version: 1.0.1
       walk-sync:
         specifier: ^3.0.0
         version: 3.0.0
@@ -48,6 +45,9 @@ importers:
       release-plan:
         specifier: ^0.9.0
         version: 0.9.0(encoding@0.1.13)
+      resolve-bin:
+        specifier: ^1.0.1
+        version: 1.0.1
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       package-up:
         specifier: ^5.0.0
         version: 5.0.0
+      resolve-bin:
+        specifier: ^1.0.1
+        version: 1.0.1
       walk-sync:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1940,6 +1943,9 @@ packages:
   find-index@1.1.1:
     resolution: {integrity: sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==}
 
+  find-parent-dir@0.3.1:
+    resolution: {integrity: sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==}
+
   find-up-simple@1.0.0:
     resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
     engines: {node: '>=18'}
@@ -3470,6 +3476,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-bin@1.0.1:
+    resolution: {integrity: sha512-4G9C3udcDB1c9qaopB+9dygm2bMyF2LeJ2JHBIc24N7ob+UuSSwX3ID1hQwpDEQep9ZRNdhT//rgEd6xbWA/SA==}
 
   resolve-dir@1.0.1:
     resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
@@ -6509,6 +6518,8 @@ snapshots:
 
   find-index@1.1.1: {}
 
+  find-parent-dir@0.3.1: {}
+
   find-up-simple@1.0.0: {}
 
   find-up@4.1.0:
@@ -8132,6 +8143,10 @@ snapshots:
   require-directory@2.1.1: {}
 
   requires-port@1.0.0: {}
+
+  resolve-bin@1.0.1:
+    dependencies:
+      find-parent-dir: 0.3.1
 
   resolve-dir@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      package-up:
+        specifier: ^5.0.0
+        version: 5.0.0
       walk-sync:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1937,6 +1940,10 @@ packages:
   find-index@1.1.1:
     resolution: {integrity: sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==}
 
+  find-up-simple@1.0.0:
+    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
+    engines: {node: '>=18'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3177,6 +3184,10 @@ packages:
   package-json@6.5.0:
     resolution: {integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==}
     engines: {node: '>=8'}
+
+  package-up@5.0.0:
+    resolution: {integrity: sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==}
+    engines: {node: '>=18'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6498,6 +6509,8 @@ snapshots:
 
   find-index@1.1.1: {}
 
+  find-up-simple@1.0.0: {}
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -7845,6 +7858,10 @@ snapshots:
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
       semver: 6.3.1
+
+  package-up@5.0.0:
+    dependencies:
+      find-up-simple: 1.0.0
 
   parent-module@1.0.1:
     dependencies:

--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -12,6 +12,8 @@ const appName = 'fancy-app-in-test';
 describe('basic functionality', function () {
   let tmpDir;
 
+  let emberCli = join(__dirname, '../node_modules/ember-cli/bin/ember');
+
   beforeAll(async () => {
     tmpDir = await tmp.dir({ unsafeCleanup: true });
 
@@ -24,7 +26,7 @@ describe('basic functionality', function () {
       '--skip-git',
     ];
 
-    await execa('ember', emberCliArgs, {
+    await execa(emberCli, emberCliArgs, {
       cwd: tmpDir.path,
       preferLocal: true,
     });

--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -5,14 +5,13 @@ import { execa } from 'execa';
 import copyWithTemplate from '../lib/copy-with-template';
 import { existsSync, writeFileSync } from 'fs';
 import stripAnsi from 'strip-ansi';
+import { emberCli } from './helpers.mjs';
 
 const blueprintPath = join(__dirname, '..');
 const appName = 'fancy-app-in-test';
 
 describe('basic functionality', function () {
   let tmpDir;
-
-  let emberCli = join(__dirname, '../node_modules/ember-cli/bin/ember');
 
   beforeAll(async () => {
     tmpDir = await tmp.dir({ unsafeCleanup: true });

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -65,6 +65,8 @@ export function resolveBin(packageName, binName = packageName) {
   return join(packageDir, binPath);
 }
 
-export function emberCLI() {
+function findEmber() {
   return resolveBin('ember-cli', 'ember');
 }
+
+export const emberCli = findEmber();

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -1,0 +1,70 @@
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import assert from 'node:assert';
+
+import { packageUpSync } from 'package-up';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * require.resolve finds the *entrypoint*
+ * we then need to find the package directory,
+ * read the package.json
+ * see what the bin entries are,
+ * grab the path for the bin (by name),
+ * and then return that path (absolute path to that bin)
+ */
+export function resolveBin(packageName, binName = packageName) {
+  // NOTE: will fail if there is no '.' export.
+  //       (or main)
+  let entrypoint = require.resolve(packageName);
+
+  let manifestPath = packageUpSync({ cwd: entrypoint });
+  let buffer = readFileSync(manifestPath);
+  let manifest = JSON.parse(buffer.toString());
+  let packageDir = dirname(manifestPath);
+
+  assert(
+    manifest.name === packageName,
+    `Found package manifest at ${manifestPath}, but it was not for ${packageName}. Cannot continue.`,
+  );
+
+  assert(
+    manifest.bin,
+    `The specified (and found) package, ${packageName}, does not specify a 'bin' entry in its package.json`,
+  );
+
+  let binPath;
+
+  if (typeof manifest.bin === 'string') {
+    assert(
+      packageName === binName,
+      `The 'bin' entry for ${packageName} can only be the same as the packageName. The requested bin ${binName} is not availabel.`,
+    );
+
+    binPath = manifest.bin;
+  }
+
+  if (!binPath) {
+    assert(
+      typeof manifest.bin === 'object' &&
+        !Array.isArray(manifest.bin) &&
+        manifest.bin !== null,
+      `The 'bin' entry for ${packageName} must be an object.`,
+    );
+
+    binPath = manifest.bin?.[binName];
+  }
+
+  assert(
+    binPath,
+    `Could not determine 'bin', ${binName}, for package: ${packageName}.`,
+  );
+
+  return join(packageDir, binPath);
+}
+
+export function emberCLI() {
+  return resolveBin('ember-cli', 'ember');
+}

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -1,72 +1,7 @@
-import { createRequire } from 'node:module';
-import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import assert from 'node:assert';
-
-import { packageUpSync } from 'package-up';
-
-const require = createRequire(import.meta.url);
-
-/**
- * require.resolve finds the *entrypoint*
- * we then need to find the package directory,
- * read the package.json
- * see what the bin entries are,
- * grab the path for the bin (by name),
- * and then return that path (absolute path to that bin)
- */
-export function resolveBin(packageName, binName = packageName) {
-  // NOTE: will fail if there is no '.' export.
-  //       (or main)
-  let entrypoint = require.resolve(packageName);
-
-  let manifestPath = packageUpSync({ cwd: entrypoint });
-  let buffer = readFileSync(manifestPath);
-  let manifest = JSON.parse(buffer.toString());
-  let packageDir = dirname(manifestPath);
-
-  assert(
-    manifest.name === packageName,
-    `Found package manifest at ${manifestPath}, but it was not for ${packageName}. Cannot continue.`,
-  );
-
-  assert(
-    manifest.bin,
-    `The specified (and found) package, ${packageName}, does not specify a 'bin' entry in its package.json`,
-  );
-
-  let binPath;
-
-  if (typeof manifest.bin === 'string') {
-    assert(
-      packageName === binName,
-      `The 'bin' entry for ${packageName} can only be the same as the packageName. The requested bin ${binName} is not availabel.`,
-    );
-
-    binPath = manifest.bin;
-  }
-
-  if (!binPath) {
-    assert(
-      typeof manifest.bin === 'object' &&
-        !Array.isArray(manifest.bin) &&
-        manifest.bin !== null,
-      `The 'bin' entry for ${packageName} must be an object.`,
-    );
-
-    binPath = manifest.bin?.[binName];
-  }
-
-  assert(
-    binPath,
-    `Could not determine 'bin', ${binName}, for package: ${packageName}.`,
-  );
-
-  return join(packageDir, binPath);
-}
+import { sync as resolveBinSync } from 'resolve-bin';
 
 function findEmber() {
-  return resolveBin('ember-cli', 'ember');
+  return resolveBinSync('ember-cli', { executable: 'ember' });
 }
 
 export const emberCli = findEmber();


### PR DESCRIPTION
in some shell environments, `execa` with `ember` as the first argument was attempting to use the global installation (which may not exist!)

In this PR, I explicitly point at the local copy of ember-cli, which *should* be more robust / cross-env.