### PR TITLE
Parameterize the default tests for quickly adding scenarios to test

### DIFF
--- a/tests/default.test.mjs
+++ b/tests/default.test.mjs
@@ -4,79 +4,93 @@ import { existsSync, writeFileSync } from 'fs';
 import stripAnsi from 'strip-ansi';
 import { newProjectWithFixtures } from './helpers.mjs';
 
+const SCENARIOS = [
+  {
+    flags: [
+      /* none, default */
+    ],
+    fixturePath: join(import.meta.dirname, 'fixture'),
+  },
+];
+
 describe('basic functionality', function () {
-  let project = newProjectWithFixtures({
-    fixturePath: join(__dirname, 'fixture'),
-  });
-
-  it('verify files', async function () {
-    expect(
-      !existsSync(join(project.dir(), 'app/index.html')),
-      'the app index.html has been removed',
-    );
-    expect(
-      existsSync(join(project.dir(), 'index.html')),
-      'the root index.html has been added',
-    );
-  });
-
-  it('successfully lints', async function () {
-    let result = await project.execa('pnpm', ['lint']);
-
-    console.log(result.stdout);
-  });
-
-  it('successfully builds', async function () {
-    let result = await project.execa('pnpm', ['build']);
-
-    console.log(result.stdout);
-  });
-
-  it('successfully runs tests', async function () {
-    let result;
-
-    try {
-      result = await project.execa('pnpm', ['test:ember']);
-    } catch (err) {
-      console.log(err.stdout, err.stderr);
-      throw err;
-    }
-
-    // make sure that each of the tests that we expect actually show up
-    // alternatively we can change this to search for `pass 3`
-    expect(result.stdout).to.contain(
-      'Acceptance | welcome page: visiting /index shows the welcome page',
-    );
-    expect(result.stdout).to.contain('Acceptance | styles: visiting /styles');
-
-    console.log(result.stdout);
-  });
-
-  it('successfully runs tests in dev mode', async function () {
-    await project.$`pnpm install --save-dev testem http-proxy`;
-    let appURL;
-
-    let server;
-
-    try {
-      server = project.execa('pnpm', ['start']);
-
-      await new Promise((resolve) => {
-        server.stdout.on('data', (line) => {
-          let result = /Local:\s+(https?:\/\/.*)\//g.exec(
-            stripAnsi(line.toString()),
-          );
-
-          if (result) {
-            appURL = result[1];
-            resolve();
-          }
-        });
+  for (let { flags, fixturePath } of SCENARIOS) {
+    describe(`with flags: '${flags.join(' ')}'`, function () {
+      let project = newProjectWithFixtures({
+        fixturePath,
+        flags,
       });
 
-      writeFileSync(
-        join(project.dir(), 'testem-dev.js'),
-        `module.exports = {
+      it('verify files', async function () {
+        expect(
+          !existsSync(join(project.dir(), 'app/index.html')),
+          'the app index.html has been removed',
+        );
+        expect(
+          existsSync(join(project.dir(), 'index.html')),
+          'the root index.html has been added',
+        );
+      });
+
+      it('successfully lints', async function () {
+        let result = await project.execa('pnpm', ['lint']);
+
+        console.log(result.stdout);
+      });
+
+      it('successfully builds', async function () {
+        let result = await project.execa('pnpm', ['build']);
+
+        console.log(result.stdout);
+      });
+
+      it('successfully runs tests', async function () {
+        let result;
+
+        try {
+          result = await project.execa('pnpm', ['test:ember']);
+        } catch (err) {
+          console.log(err.stdout, err.stderr);
+          throw 'Failed to successfully run test:ember';
+        }
+
+        // make sure that each of the tests that we expect actually show up
+        // alternatively we can change this to search for `pass 3`
+        expect(result.stdout).to.contain(
+          'Acceptance | welcome page: visiting /index shows the welcome page',
+        );
+        expect(result.stdout).to.contain(
+          'Acceptance | styles: visiting /styles',
+        );
+
+        console.log(result.stdout);
+      });
+
+      it('successfully runs tests in dev mode', async function () {
+        await project.$`pnpm install --save-dev testem http-proxy`;
+        let appURL;
+
+        let server;
+
+        try {
+          server = project.execa('pnpm', ['start']);
+
+          await new Promise((resolve) => {
+            server.stdout.on('data', (line) => {
+              let result = /Local:\s+(https?:\/\/.*)\//g.exec(
+                stripAnsi(line.toString()),
+              );
+
+              if (result) {
+                appURL = result[1];
+                resolve();
+              }
+            });
+          });
+
+          writeFileSync(
+            join(project.dir(), 'testem-dev.js'),
+            `module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
@@ -101,21 +115,23 @@ describe('basic functionality', function () {
   ],
 };
 `,
-      );
+          );
 
-      let testResult = await project.execa('pnpm', [
-        'testem',
-        '--file',
-        'testem-dev.js',
-        'ci',
-      ]);
-      expect(testResult.exitCode).to.eq(0, testResult.output);
-    } finally {
-      server?.kill('SIGINT');
-    }
-  });
+          let testResult = await project.execa('pnpm', [
+            'testem',
+            '--file',
+            'testem-dev.js',
+            'ci',
+          ]);
+          expect(testResult.exitCode).to.eq(0, testResult.output);
+        } finally {
+          server?.kill('SIGINT');
+        }
+      });
 
-  it('successfully optimizes deps', function () {
-    return project.execa('pnpm', ['vite', 'optimize', '--force']);
-  });
+      it('successfully optimizes deps', function () {
+        return project.execa('pnpm', ['vite', 'optimize', '--force']);
+      });
+    });
+  }
 });


### PR DESCRIPTION
Extracted from #80 

The "default tests" are tests that run for every scenario. They ensure that, out of the box, things like linting, type checking (if available), tests, etc pass with exit status 0.