### PR TITLE
fix all @embroider/virtual renames

### DIFF
--- a/files-override/js/app/app.js
+++ b/files-override/js/app/app.js
@@ -1,5 +1,5 @@
 import Application from '@ember/application';
-import compatModules from '@embroider/core/entrypoint';
+import compatModules from '@embroider/virtual/compat-modules';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';

--- a/files-override/js/tests/index.html
+++ b/files-override/js/tests/index.html
@@ -8,9 +8,9 @@
 
     {{content-for "head"}} {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="/@embroider/core/vendor.css" />
+    <link rel="stylesheet" href="/@embroider/virtual/vendor.css" />
     <link rel="stylesheet" href="/assets/<%= name %>.css" />
-    <link rel="stylesheet" href="/@embroider/core/test-support.css" />
+    <link rel="stylesheet" href="/@embroider/virtual/test-support.css" />
 
     {{content-for "head-footer"}} {{content-for "test-head-footer"}}
   </head>
@@ -25,7 +25,7 @@
     </div>
 
     <script src="/testem.js" integrity="" data-embroider-ignore></script>
-    <script src="/@embroider/core/vendor.js"></script>
+    <script src="/@embroider/virtual/vendor.js"></script>
     <script src="/@embroider/core/test-support.js"></script>
     <script type="module">import "ember-testing";</script>
 

--- a/files/js/index.html
+++ b/files/js/index.html
@@ -8,7 +8,7 @@
 
     {{content-for "head"}}
 
-    <link integrity="" rel="stylesheet" href="/@embroider/core/vendor.css">
+    <link integrity="" rel="stylesheet" href="/@embroider/virtual/vendor.css">
     <link integrity="" rel="stylesheet" href="/assets/<%= name %>.css">
 
     {{content-for "head-footer"}}
@@ -16,7 +16,7 @@
   <body>
     {{content-for "body"}}
 
-    <script src="/@embroider/core/vendor.js"></script>
+    <script src="/@embroider/virtual/vendor.js"></script>
     <script type="module">
       import Application from './app/app';
       import environment from './app/config/environment';

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "tmp-promise": "^3.0.3",
     "vitest": "^1.6.0"
   },
-  "packageManager": "pnpm@9.5.0"
+  "packageManager": "pnpm@9.12.0+sha512.4abf725084d7bcbafbd728bfc7bee61f2f791f977fd87542b3579dcb23504d170d46337945e4c66485cd12d588a0c0e570ed9c477e7ccdd8507cf05f3f92eaca"
 }


### PR DESCRIPTION
Turns out the recent renames meant the blueprint was broken during ViteConf 🫠 