### PR TITLE
Create new 'output' script for a short way to run the generator

### DIFF
--- a/lib/bin/new-app.mjs
+++ b/lib/bin/new-app.mjs
@@ -1,0 +1,24 @@
+/**
+ * Usage:
+ *
+ *   pnpm output:new [...flags]
+ *
+ * Example:
+ *
+ *   pnpm output --typescript
+ *
+ *
+ */
+
+import { newApp } from '../new-app.mjs';
+
+const [, , ...args] = process.argv;
+
+let name = `my-ember-vite-app`;
+let info = await newApp({ name, flags: args });
+
+console.info(`
+
+  New app created in ${info.dir}
+
+`);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "vitest",
+    "output": "node ./lib/bin/new-app.mjs",
     "output:fixture": "node ./lib/bin/output-fixture.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
I think this is handy for local testing, as we can cd to the directory and poke around and fix things before re-applying those fixes in the blueprint files.