### PR TITLE
Remove ember-cli-inject-live-reload dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ module.exports = {
         'ember-cli-app-version',
         'ember-cli-clean-css',
         'ember-cli-dependency-checker',
+        'ember-cli-inject-live-reload',
         'ember-cli-sri',
         'ember-cli-terser',
         // Linting


### PR DESCRIPTION
As far as I can tell `ember-cli-inject-live-reload` is no longer used and live reloading is handled by the Vite's "Hot Module Replacement" feature.

References

- [ember-cli-inject-live-reload](https://github.com/ember-cli/ember-cli-inject-live-reload)
- [Vite's Hot Module Replacement](https://vite.dev/guide/features.html#hot-module-replacement)