### PR TITLE
fix upstream issue with typescript-eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,9 +164,9 @@ module.exports = {
               '@glint/environment-ember-template-imports@unstable',
               '@glint/template@unstable',
               '@types/eslint__js',
-              'typescript-eslint@^8.13.0',
-              '@typescript-eslint/eslint-plugin@^8.13.0',
-              '@typescript-eslint/parser@^8.13.0',
+              'typescript-eslint@^8.14.1-alpha.8',
+              '@typescript-eslint/eslint-plugin@^8.14.1-alpha.8',
+              '@typescript-eslint/parser@^8.14.1-alpha.8',
             ]
           : []),
       ],


### PR DESCRIPTION
This is caused by https://github.com/typescript-eslint/typescript-eslint/issues/10338 

It's safe to set our dependencies as `^8.14.1-alpha.8` because when `^8.14.1` is released it will pick up the non-alpha version 👍 you can take a look at https://semver.otterlord.dev/?package=typescript-eslint&range=%5E8.8.2-alpha.11 as an example of it doing the thing we'd expect 