### PR TITLE
bump @ember/test-helpers and stop ember-qunit from using requirejs

### DIFF
--- a/files-override/js/tests/test-helper.js
+++ b/files-override/js/tests/test-helper.js
@@ -10,5 +10,5 @@ export function start() {
 
   setup(QUnit.assert);
 
-  qunitStart();
+  qunitStart({ loadTests: false });
 }

--- a/files-override/ts/tests/test-helper.ts
+++ b/files-override/ts/tests/test-helper.ts
@@ -10,5 +10,5 @@ export function start() {
 
   setup(QUnit.assert);
 
-  qunitStart();
+  qunitStart({ loadTests: false });
 }

--- a/index.js
+++ b/index.js
@@ -137,6 +137,7 @@ module.exports = {
         'ember-template-lint@^6.0.0',
 
         '@ember/string@^4.0.0',
+        '@ember/test-helpers@^4.0.0',
         'ember-resolver@^13.0.2',
         'ember-load-initializers@^3.0.1',
         'qunit@^2.22.0',


### PR DESCRIPTION
Now that embroider no longer has requirejs we can't have any dependencies that use that functionality 👍 