### PR TITLE
add babel-preset-env to the babel config

### DIFF
--- a/files/js/babel.config.cjs
+++ b/files/js/babel.config.cjs
@@ -2,8 +2,10 @@ const {
   babelCompatSupport,
   templateCompatSupport,
 } = require('@embroider/compat/babel');
+const targets = require('./config/targets');
 
 module.exports = {
+  presets: [['@babel/preset-env', { targets, modules: false }]],
   plugins: [
     [
       'babel-plugin-ember-template-compilation',

--- a/files/ts/babel.config.cjs
+++ b/files/ts/babel.config.cjs
@@ -2,8 +2,10 @@ const {
   babelCompatSupport,
   templateCompatSupport,
 } = require('@embroider/compat/babel');
+const targets = require('./config/targets');
 
 module.exports = {
+  presets: [['@babel/preset-env', { targets, modules: false }]],
   plugins: [
     [
       '@babel/plugin-transform-typescript',

--- a/index.js
+++ b/index.js
@@ -136,6 +136,7 @@ module.exports = {
         '@babel/eslint-parser@^7.25.9',
         '@babel/plugin-transform-runtime@^7.25.9',
         '@babel/runtime@^7.26.0',
+        '@babel/preset-env@^7.26.0',
         'ember-template-lint@^6.0.0',
 
         '@ember/string@^4.0.0',


### PR DESCRIPTION
This one probably needs a bit of a discussion. I'm not exactly sure we want to do this 🤔 should we consider implementing browser compatibility using Vite's config instead of going through babel? https://vite.dev/guide/build.html#browser-compatibility