### PR TITLE
Add vite/client types

### DIFF
--- a/files-override/ts/types/index.d.ts
+++ b/files-override/ts/types/index.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="@embroider/core/virtual" />
+/// <reference types="vite/client" />


### PR DESCRIPTION
This makes asset imports that vite supports out the box work without typescript complaining.