### PR TITLE
fix typescript: eslint ignores needs to be the lone key to act globally

### DIFF
--- a/files-override/js/eslint.config.mjs
+++ b/files-override/js/eslint.config.mjs
@@ -21,7 +21,16 @@ export default [
   js.configs.recommended,
   prettier,
   {
+    /**
+     * Ignores must be in their own object
+     * https://eslint.org/docs/latest/use/configure/ignore
+     */
     ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  {
+    /**
+     * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+     */
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
     },

--- a/files-override/ts/eslint.config.mjs
+++ b/files-override/ts/eslint.config.mjs
@@ -32,6 +32,21 @@ export default ts.config(
   js.configs.recommended,
   prettier,
   {
+    /**
+     * Ignores must be in their own object
+     * https://eslint.org/docs/latest/use/configure/ignore
+     */
+    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
+  },
+  {
+    /**
+     * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options
+     */
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
+  },
+  {
     files: ['**/*.js'],
     languageOptions: {
       parser: babelParser,
@@ -133,14 +148,5 @@ export default ts.config(
         ...globals.node,
       },
     },
-  },
-  /**
-   * Settings
-   */
-  {
-    ignores: ['dist/', 'node_modules/', 'coverage/', '!**/.*'],
-    linterOptions: {
-      reportUnusedDisableDirectives: 'error',
-    },
-  },
+  }
 );


### PR DESCRIPTION
This ensures the ignores are respected globally to stop eslint from linting inside of dist (and other listed directories).