### PR TITLE
Link to on disk app.css in index.html so it is processed by vite

### DIFF
--- a/files-override/shared/index.html
+++ b/files-override/shared/index.html
@@ -9,7 +9,7 @@
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="/@embroider/virtual/vendor.css">
-    <link integrity="" rel="stylesheet" href="/assets/<%= name %>.css">
+    <link integrity="" rel="stylesheet" href="/app/styles/app.css">
 
     {{content-for "head-footer"}}
   </head>

--- a/files-override/shared/tests/index.html
+++ b/files-override/shared/tests/index.html
@@ -9,7 +9,7 @@
     {{content-for "head"}} {{content-for "test-head"}}
 
     <link rel="stylesheet" href="/@embroider/virtual/vendor.css" />
-    <link rel="stylesheet" href="/assets/<%= name %>.css" />
+    <link rel="stylesheet" href="/app/styles/app.css">
     <link rel="stylesheet" href="/@embroider/virtual/test-support.css" />
 
     {{content-for "head-footer"}} {{content-for "test-head-footer"}}


### PR DESCRIPTION
Closes #132

We may want to add something to the compat plugin in embroider to delete the unprocessed `dist/assets/app-name.css` to go along with this change.