### PR TITLE
Set QUnit preconf autostart to false to ensure qunit waits correctly for top level await in app

### DIFF
--- a/files-override/shared/tests/index.html
+++ b/files-override/shared/tests/index.html
@@ -8,6 +8,10 @@
 
     {{content-for "head"}} {{content-for "test-head"}}
 
+    <script type="module">
+      window.qunit_config_autostart = false;
+    </script>
+
     <link rel="stylesheet" href="/@embroider/virtual/vendor.css" />
     <link rel="stylesheet" href="/assets/<%= name %>.css" />
     <link rel="stylesheet" href="/@embroider/virtual/test-support.css" />


### PR DESCRIPTION
Without this when using top level await in your app the tests will break.

```
[test:ember] not ok 1 Chrome 131.0 - [undefined ms] - Global error: Uncaught Error: Called start() while test already started running at http://localhost:7357/assets/tests-BE6RHohS.js, line 45
```

Somehow, and I don't know why, autostart is true when QUnit starts up when the app uses a top level await, a component like this can recreate the issue.

```js
import Component from '@glimmer/component';
const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
await sleep(1000);

export default class MyComponent extends Component {}
```

I found this by using dynamic import at the top level to make a large library it's own chunk. I think it's down to bundle ordering, but I'm not sure. 

Using qunit's [preconfig option](https://qunitjs.com/api/config/#preconfiguration) ensures autostart is false and top level awaits don't break the test suite.

More context on discord
https://discord.com/channels/480462759797063690/568935504288940056/1319396012506484850
https://discord.com/channels/480462759797063690/568935504288940056/1320540566274179182
https://discord.com/channels/480462759797063690/568935504288940056/1321109960117063773