### PR TITLE
Remove extraneous loadTests: false

### DIFF
--- a/files-override/js/tests/test-helper.js
+++ b/files-override/js/tests/test-helper.js
@@ -11,5 +11,5 @@ export function start() {
   setup(QUnit.assert);
   setupEmberOnerrorValidation();
 
-  qunitStart({ loadTests: false });
+  qunitStart();
 }


### PR DESCRIPTION
For `test-helpers.ts` this was already removed in https://github.com/embroider-build/app-blueprint/pull/145, but the JS-version still has it. 