### PR TITLE
add proper versioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = {
       'save-dev': true,
       verbose: false,
       packages: [
-        '@babel/runtime^7.0.0',
+        '@babel/runtime@^7.0.0',
         '@embroider/core@^4.0.0-alpha.0',
         '@embroider/vite@^1.0.0-alpha.0',
         '@embroider/compat@^4.0.0-alpha.0',


### PR DESCRIPTION
In https://github.com/embroider-build/app-blueprint/pull/163 I added `@babel/runtime` as devDependency to the dependencies that the blueprint installs. However, I noticed after the fact that I forgot a `@` before the version.

I quickly tested creating a new app using the blueprint and I don't seem to have the issue that I used to get (before https://github.com/embroider-build/app-blueprint/pull/163), however I feel like it should be aligned with the other dependencies we install there.