### PR TITLE
Pin babel-plugin-ember-template-compilation to v2 for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = {
         '@rollup/plugin-babel',
         'decorator-transforms',
         '@babel/plugin-transform-runtime',
-        'babel-plugin-ember-template-compilation',
+        'babel-plugin-ember-template-compilation@^2.4.1', // v3 is an ESM module that is not yet compatible with the babel.config.cfs we generate
 
         '@ember/string@^4.0.0',
         '@ember/test-helpers@^4.0.0',


### PR DESCRIPTION
### Problem

 babel-plugin-ember-template-compilation v3 was released as an ESM module, but that causes errors like:
 > Parsing error: [BABEL]: You appear to be using a native ECMAScript module plugin, which is only supported when running Babel asynchronously or when using the Node.js `--experimental-require-module` flag.
    
 ### Solution

Remain on babel-plugin-ember-template-compilation v2 for now
