### PR TITLE
Point users to @ember/app-blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This has been replaced by the app blueprint, [@ember/app-blueprint](https://github.com/ember-cli/ember-app-blueprint).
+
+<details>
+<summary>View the outdated README</summary>
+
 # @embroider/app-blueprint
 
 **Very** experimental blueprint for scaffolding Ember v2 apps with Vite
@@ -36,3 +42,4 @@ Use [ember-cli-update](https://github.com/ember-cli/ember-cli-update) to update 
 ```bash
 pnpm dlx ember-cli-update
 ```
+</details>


### PR DESCRIPTION
TIL to [stop using this](https://discord.com/channels/480462759797063690/480462759797063692/1379897633614856365) and start using the other blueprint.  This PR updates the README to point folks in the right direction.
